### PR TITLE
Modified words.js and server.js

### DIFF
--- a/lib/words.js
+++ b/lib/words.js
@@ -1,11 +1,13 @@
 var _ = require('underscore');
 
+
 function search(word) {
   var exclude = _.filter(word, function(w) {
     return w != "?" && w != "_";
   });
 
-  var excludePattern = "";
+  var excludePattern = "",
+    toSearch = "";
 
   _.each(exclude, function(c) {
     excludePattern += "^" + c;
@@ -28,7 +30,11 @@ function search(word) {
     return w.match(new RegExp(toSearch, "i"));
   });
 
-  return result;
+  return {
+    result: result,
+    excludePattern: excludePattern,
+    searchPattern: toSearch
+  };
 }
 
 exports.search = search;

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.get('/', function (req, res) {
 });
 
 app.post('/search', function (req, res) {
-  var result = words.search(req.body.pattern);
+  var result = words.search(req.body.pattern).result;
   res.render('result', { words: result, pattern: req.body.pattern });
 });
 


### PR DESCRIPTION
expose regex patterns for testing and altered the way the get call accesses the results. I'm thinking that this makes the regex magic easier to test by exposing the patterns that are created and executed.
